### PR TITLE
Fixed readme and added EOL linter config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,8 @@
     "react/function-component-definition": [
       "error",
       {
-        "namedComponents": ["arrow-function"]
+        "namedComponents": ["arrow-function"],
+				"endOfLine":"auto"
       }
     ],
     "react/prop-types": 0,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The things our app can do to help you on your adventure:
 
 After cloning, you need to install dependencies from `package.json`. Run the following commands in the CMD tool:
 
-`npm install` to install required node modules;
+`npm ci` to install required node modules;
 
 `npm start` to run the server
 


### PR DESCRIPTION
## Summary

Fixed the linter making a fuss about line end characters.
Modified `README.md` to include `npm ci` instead of `npm install` to prevent `package-lock.json` conflicts.

### Screenshot
Previous:
![image](https://user-images.githubusercontent.com/43648634/203492862-73ae3bbd-b9a8-4402-8e69-21bfb0d83f0a.png)

Current:
![image](https://user-images.githubusercontent.com/43648634/203492826-9c5a9a05-a56d-46eb-a7fb-f2b94ddb70d6.png)


## How this was tested?

Manually

### List of steps to manually test introduced functionality:

- `git clone` the repo
- to fetch the required modules, run `npm ci`

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have added tests for new functionality
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings
-   [ ] My pull-request is shorter than 500 lines
