### PR TITLE
Turned off react/react-in-jsx-scope eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
   "plugins": ["react", "prettier"],
   "rules": {
     "prettier/prettier": "error",
+    "react/react-in-jsx-scope": "off",
     "react/function-component-definition": [
       "error",
       {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import RecipesList from "./components/RecipesList";
 
 const App = () => {

--- a/src/components/RecipeItem/RecipeItem.jsx
+++ b/src/components/RecipeItem/RecipeItem.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   ItemImage,
   ItemInfo,

--- a/src/components/RecipesList/RecipesList.jsx
+++ b/src/components/RecipesList/RecipesList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import RecipeItem from "../RecipeItem";
 import fetchRecipes from "../../api/fetchRecipes";
 

--- a/src/components/SearchBox/SearchBox.jsx
+++ b/src/components/SearchBox/SearchBox.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { SearchDiv, SearchTextInput, SearchInput } from "./styles";
 import fetchRecipes from "../../api/fetchRecipes";
 


### PR DESCRIPTION
## Summary

ESLint does not require `import React from "react"` anymore